### PR TITLE
Tentative implementation for plaquette sides

### DIFF
--- a/src/tqec/templates/constructions/qubit.py
+++ b/src/tqec/templates/constructions/qubit.py
@@ -120,7 +120,7 @@ class DenseQubitSquareTemplate(ComposedTemplateWithSides):
 
     @override
     def get_plaquette_indices_on_sides(self, sides: list[TemplateSide]) -> list[int]:
-        return sorted(set(sum((self._side_indices[side] for side in sides), start=[])))
+        return sum((self._side_indices[side] for side in sides), start=[])
 
 
 class QubitVerticalBorders(ComposedTemplateWithSides):
@@ -205,7 +205,7 @@ class QubitVerticalBorders(ComposedTemplateWithSides):
 
     @override
     def get_plaquette_indices_on_sides(self, sides: list[TemplateSide]) -> list[int]:
-        return sorted(set(sum((self._side_indices[side] for side in sides), start=[])))
+        return sum((self._side_indices[side] for side in sides), start=[])
 
 
 class QubitHorizontalBorders(ComposedTemplateWithSides):
@@ -282,4 +282,4 @@ class QubitHorizontalBorders(ComposedTemplateWithSides):
 
     @override
     def get_plaquette_indices_on_sides(self, sides: list[TemplateSide]) -> list[int]:
-        return sorted(set(sum((self._side_indices[side] for side in sides), start=[])))
+        return sum((self._side_indices[side] for side in sides), start=[])


### PR DESCRIPTION
This is simply to demonstrate one way of fixing the issue "pipes do not have the same plaquette indices as block sides".

This should work because:
- the side plaquette indices are added in the order in which sides are provided in `get_plaquette_indices_on_sides` (starting from this PR),
- values in `_TEMPLATE_BOUNDARIES` are also correctly ordered (for `Direction3D.X`, `TOP` and `BOTTOM` are at the same position),

I could not test though, so it might fail miserably due to something I missed.